### PR TITLE
#37: Used latest release versions of JUnit 5 libraries

### DIFF
--- a/scott-examples/junit5/pom.xml
+++ b/scott-examples/junit5/pom.xml
@@ -48,7 +48,7 @@
 					<dependency>
 						<groupId>org.junit.platform</groupId>
 						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>1.0.0-M4</version>
+						<version>1.0.1</version>
 					</dependency>
 				</dependencies>
 				<configuration>
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.0.0-M4</version>
+			<version>5.0.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/scott-tests/junit5-tests/pom.xml
+++ b/scott-tests/junit5-tests/pom.xml
@@ -48,7 +48,7 @@
 					<dependency>
 						<groupId>org.junit.platform</groupId>
 						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>1.0.0-M4</version>
+						<version>1.0.1</version>
 					</dependency>
 				</dependencies>
 				<configuration>
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.0.0-M4</version>
+			<version>5.0.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/scott-tests/junit5-tests/src/test/java/hu/advancedweb/scott/TestInfoTest.java
+++ b/scott-tests/junit5-tests/src/test/java/hu/advancedweb/scott/TestInfoTest.java
@@ -14,10 +14,10 @@ public class TestInfoTest {
 
 	@Test
 	@DisplayName("TEST 1")
-	@Tag("my tag")
+	@Tag("my-tag")
 	void test1(TestInfo testInfo) {
 		assertEquals("TEST 1", testInfo.getDisplayName());
-		assertTrue(testInfo.getTags().contains("my tag"));
+		assertTrue(testInfo.getTags().contains("my-tag"));
 		assertTrue(TestHelper.getLastRecordedStateForVariable("testInfo") != null);
 	}
 

--- a/scott/pom.xml
+++ b/scott/pom.xml
@@ -150,7 +150,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.0.0-M4</version>
+			<version>5.0.1</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/scott/src/main/java/hu/advancedweb/scott/runtime/ScottJUnit5Extension.java
+++ b/scott/src/main/java/hu/advancedweb/scott/runtime/ScottJUnit5Extension.java
@@ -1,15 +1,15 @@
 package hu.advancedweb.scott.runtime;
 
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
-import org.junit.jupiter.api.extension.TestExtensionContext;
 
 import hu.advancedweb.scott.runtime.report.FailureRenderer;
 
 public class ScottJUnit5Extension implements TestExecutionExceptionHandler {
 
 	@Override
-	public void handleTestExecutionException(TestExtensionContext context, Throwable throwable) throws Throwable {
-		String testClassName = context.getTestClass().isPresent() ? context.getTestClass().get().getTypeName() : null; 
+	public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+		String testClassName = context.getTestClass().isPresent() ? context.getTestClass().get().getTypeName() : null;
 		String testMethodName = context.getTestMethod().isPresent() ? context.getTestMethod().get().getName() : null;
 
 		if (throwable instanceof AssertionError) {


### PR DESCRIPTION
- Bumped org.junit.jupiter:junit-jupiter-engine to 5.0.1
- Bumped org.junit.platform:junit-platform-surefire-provider to 1.0.1
- TestExtensionContext was deprecated since 5.0.0.M5. Used ExtensionContext
instead as advised in http://junit.org/junit5/docs/current/user-guide/#release-notes-5.0.0-m5
- Tags can't contain whitespace characters, hence updated tag in TestInfoTest.java